### PR TITLE
Upgrading to @dolittle/projections 2.1.0

### DIFF
--- a/Source/typescript/backend/package.json
+++ b/Source/typescript/backend/package.json
@@ -36,7 +36,7 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
-        "@dolittle/projections": "2.0.0",
+        "@dolittle/projections": "2.1.0",
         "@dolittle/sdk": "14.3.0",
         "@types/mongodb": "3.6.8",
         "apollo-server-express": "2.19.0",


### PR DESCRIPTION
### Changed

- @dolittle/projections upgraded to v2.1.0 for supporting Guid conversion to and from Mongo
