### PR TITLE
Move Apollo + GraphQL dependencies to Web

### DIFF
--- a/Source/react/package.json
+++ b/Source/react/package.json
@@ -43,11 +43,6 @@
         "@types/react": "16.9.10",
         "@types/react-dom": "16.9.10",
         "@types/react-router-dom": "5.1.6",
-        "apollo-cache-inmemory": "1.6.5",
-        "apollo-client": "2.6.8",
-        "apollo-link-http": "1.5.17",
-        "graphql": "15.4.0",
-        "graphql-tag": "2.11.0",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-router-dom": "5.2.0"

--- a/Source/web/package.json
+++ b/Source/web/package.json
@@ -38,6 +38,11 @@
     },
     "dependencies": {
         "@dolittle/vanir-dependency-inversion": "9.20.0",
+        "apollo-cache-inmemory": "1.6.5",
+        "apollo-client": "2.6.8",
+        "apollo-link-http": "1.5.17",
+        "graphql": "15.4.0",
+        "graphql-tag": "2.11.0",
         "rxjs": "6.6.0"
     },
     "devDependencies": {}


### PR DESCRIPTION
### Fixed

- Apollo + GraphQL dependencies moved from React to Web - which is more correct. If you don't use React, you'll then get the dependencies we really rely on.

