### PR TITLE
Fixed so that it includes all validators for a type - not just the first it discovers

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -42,6 +42,13 @@ namespace Backend
         public MyObjectValidator()
         {
             RuleFor(_ => _.Something).NotNull().NotEmpty().WithMessage("This should be set");
+        }
+    }
+
+    public class MySecondObjectValidator : AbstractValidator<MyObject>
+    {
+        public MySecondObjectValidator()
+        {
             RuleFor(_ => _.SomeNumber).GreaterThan(42).WithMessage("Must be greater than 42");
             RuleFor(_ => _.Concept).SetValidator(new SomeConceptValidator());
         }

--- a/Source/DotNET/Backend/GraphQL/Validation/IValidators.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/IValidators.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using FluentValidation;
 
 namespace Dolittle.Vanir.Backend.GraphQL.Validation
@@ -9,6 +10,6 @@ namespace Dolittle.Vanir.Backend.GraphQL.Validation
     public interface IValidators
     {
         bool HasFor(Type type);
-        IValidator GetFor(Type type);
+        IEnumerable<IValidator> GetFor(Type type);
     }
 }

--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
@@ -50,13 +50,16 @@ namespace Dolittle.Vanir.Backend.GraphQL.Validation
         {
             if (_validators.HasFor(type))
             {
-                var validator = _validators.GetFor(type);
+                var validators = _validators.GetFor(type);
                 var validationContextType = typeof(ValidationContext<>).MakeGenericType(type);
                 var validationContext = Activator.CreateInstance(validationContextType, instance) as IValidationContext;
-                var result = await validator.ValidateAsync(validationContext);
-                if (!result.IsValid)
+                foreach (var validator in validators)
                 {
-                    CollectErrors(context, instance, result, errors, type, propertyPath);
+                    var result = await validator.ValidateAsync(validationContext);
+                    if (!result.IsValid)
+                    {
+                        CollectErrors(context, instance, result, errors, type, propertyPath);
+                    }
                 }
             }
 


### PR DESCRIPTION
### Fixed

- [C#] During GraphQL calls, all validators for a type using FluentValidation is now included automatically. Not just the first it discovers.
