### PR TITLE
trigger-publish

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -72,8 +72,7 @@ namespace Backend
             Console.WriteLine($"Kitchen Aggregate {EventSourceId} has applied {_counter} {typeof(DishPrepared)} events");
         }
 
-        void On(DishPrepared @event)
-            => _counter++;
+        void On(DishPrepared @event) => _counter++;
     }
 
     [EventType("2977fd82-9614-4082-ab8e-d436ed129248")]

--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -143,14 +143,11 @@ namespace Backend
         }
 
         [Query("MyCustomName")]
-        public Owner TheOwner(int id)
+        public Owner TheOwner(int id) => new Owner
         {
-            return new Owner
-            {
-                Id = Guid.NewGuid(),
-                Name = "Blah"
-            };
-        }
+            Id = Guid.NewGuid(),
+            Name = "Blah"
+        };
 
         [Query]
         public Owner Something()


### PR DESCRIPTION
### Added

- [C#] Added a default public filter that will forward all events applied/committed as public - this behavior can be overridden by setting `PublishAllPublicEvents` in the `BackendArguments` used in `AddVanir()` method to false. You can then use the Dolittle configuration callback to configure your filter instead: https://dolittle.io/docs/tutorials/event-horizon/
- [C#] All types adorned with the [Projection] attribute are automatically registered as projections. Read more here: https://dolittle.io/docs/tutorials/projections/

### Changed

- [C#] Upgraded to version 8.4.0 of the SDK
