### PR TITLE
execution-context

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Things.cs
+++ b/Samples/Source/Aspnetcore/Backend/Things.cs
@@ -5,6 +5,7 @@ using Dolittle.SDK.Concepts;
 using Dolittle.SDK.Events;
 using Dolittle.SDK.Events.Handling;
 using Dolittle.SDK.Events.Store;
+using Dolittle.Vanir.Backend.Execution;
 using Dolittle.Vanir.Backend.GraphQL;
 using FluentValidation;
 using Microsoft.Extensions.Logging;
@@ -116,7 +117,7 @@ namespace Backend
         readonly IEventStore _eventStore;
         readonly IAggregateOf<Kitchen> _kitchen;
 
-        public Things(IMongoDatabase mongoDatabase, IEventStore eventStore, IAggregateOf<Kitchen> kitchen)
+        public Things(IMongoDatabase mongoDatabase, IEventStore eventStore, IAggregateOf<Kitchen> kitchen, IExecutionContextManager executionContextManager)
         {
             _mongoDatabase = mongoDatabase;
             _eventStore = eventStore;

--- a/Source/DotNET/Backend/Dolittle/DolittleContainer.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleContainer.cs
@@ -13,13 +13,13 @@ namespace Dolittle.Vanir.Backend.Dolittle
 
         public object Get(Type service, ExecutionContext context)
         {
-            ExecutionContextManager.Set(context);
+            ExecutionContextManager.SetCurrent(context);
             return ServiceProvider.GetService(service);
         }
 
         public T Get<T>(ExecutionContext context) where T : class
         {
-            ExecutionContextManager.Set(context);
+            ExecutionContextManager.SetCurrent(context);
             return (T)ServiceProvider.GetService(typeof(T));
         }
     }

--- a/Source/DotNET/Backend/Dolittle/DolittleServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Dolittle.SDK;
 using Dolittle.SDK.Aggregates;
@@ -60,7 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient(_ =>
             {
                 ThrowIfClientNotBuilt();
-                return DolittleClient.EventStore.ForTenant(ExecutionContextManager.Current.Tenant);
+                return DolittleClient.EventStore.ForTenant(ExecutionContextManager.GetCurrent().Tenant);
             });
             services.AddTransient(typeof(IAggregateOf<>), typeof(AggregateOf<>));
 

--- a/Source/DotNET/Backend/Execution/ExecutionContextAppBuilderExtensions.cs
+++ b/Source/DotNET/Backend/Execution/ExecutionContextAppBuilderExtensions.cs
@@ -8,9 +8,9 @@ using Dolittle.Vanir.Backend.Execution;
 
 namespace Microsoft.AspNetCore.Builder
 {
-    public static class ExecutionContextExtensions
+    public static class ExecutionContextAppBuilderExtensions
     {
-        const string TENANT_ID = "Tenant-ID";
+        const string _tenantId = "Tenant-ID";
 
         public static void UseExecutionContext(this IApplicationBuilder app)
         {
@@ -18,12 +18,13 @@ namespace Microsoft.AspNetCore.Builder
             {
                 var tenantId = TenantId.Development;
 
-                if (context.Request.Headers.ContainsKey(TENANT_ID))
+                if (context.Request.Headers.ContainsKey(_tenantId))
                 {
-                    tenantId = context.Request.Headers[TENANT_ID].First();
+                    tenantId = context.Request.Headers[_tenantId].First();
                 }
 
-                ExecutionContextManager.Establish(tenantId, Guid.NewGuid());
+                var executionContextManager = app.ApplicationServices.GetService(typeof(IExecutionContextManager)) as IExecutionContextManager;
+                executionContextManager.Establish(tenantId, Guid.NewGuid());
                 await next.Invoke().ConfigureAwait(false);
             });
         }

--- a/Source/DotNET/Backend/Execution/ExecutionContextManager.cs
+++ b/Source/DotNET/Backend/Execution/ExecutionContextManager.cs
@@ -13,12 +13,30 @@ using ExecutionContext = Dolittle.SDK.Execution.ExecutionContext;
 
 namespace Dolittle.Vanir.Backend.Execution
 {
-    public static class ExecutionContextManager
+    /// <summary>
+    /// Represents an implementation of <see cref="IExecutionContextManager"/>.
+    /// </summary>
+    public class ExecutionContextManager : IExecutionContextManager
     {
         static readonly AsyncLocal<ExecutionContext> _currentExecutionContext = new();
-        public static ExecutionContext Current => _currentExecutionContext.Value;
 
-        public static ExecutionContext Establish(TenantId tenantId, CorrelationId correlationId)
+        /// <summary>
+        /// Get current <see cref="ExecutionContext"/>.
+        /// </summary>
+        /// <returns>Current <see cref="ExecutionContext"/>.</returns>
+        public static ExecutionContext GetCurrent() => _currentExecutionContext.Value;
+
+        /// <summary>
+        /// Set a <see cref="ExecutionContext"/> for current call path.
+        /// </summary>
+        /// <param name="context"><see cref="ExecutionContext"/> to set.</param>
+        public static void SetCurrent(ExecutionContext context) => _currentExecutionContext.Value = context;
+
+        /// <inheritdoc/>
+        public ExecutionContext Current => _currentExecutionContext.Value;
+
+        /// <inheritdoc/>
+        public ExecutionContext Establish(TenantId tenantId, CorrelationId correlationId)
         {
             _currentExecutionContext.Value = new ExecutionContext(
                 MicroserviceManager.Current.Id,
@@ -32,6 +50,7 @@ namespace Dolittle.Vanir.Backend.Execution
             return _currentExecutionContext.Value;
         }
 
-        public static void Set(ExecutionContext context) => _currentExecutionContext.Value = context;
+        /// <inheritdoc/>
+        public void Set(ExecutionContext context) => _currentExecutionContext.Value = context;
     }
 }

--- a/Source/DotNET/Backend/Execution/ExecutionContextServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/Execution/ExecutionContextServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Vanir.Backend.Execution;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ExecutionContextServiceCollectionExtensions
+    {
+        public static void AddExecutionContext(this IServiceCollection services)
+        {
+            services.AddSingleton<IExecutionContextManager>(new ExecutionContextManager());
+        }
+    }
+}

--- a/Source/DotNET/Backend/Execution/IExecutionContextManager.cs
+++ b/Source/DotNET/Backend/Execution/IExecutionContextManager.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.SDK.Execution;
+using Dolittle.SDK.Tenancy;
+using ExecutionContext = Dolittle.SDK.Execution.ExecutionContext;
+
+namespace Dolittle.Vanir.Backend.Execution
+{
+    /// <summary>
+    /// Defines a system for working with <see cref="ExecutionContext"/>
+    /// </summary>
+    public interface IExecutionContextManager
+    {
+        /// <summary>
+        /// Get the current <see cref="ExecutionContext"/> for the current call path.
+        /// </summary>
+        ExecutionContext Current { get; }
+
+        /// <summary>
+        /// Establish an <see cref="ExecutionContext"/> for current call path.
+        /// </summary>
+        /// <param name="tenantId"><see cref="TenantId"/> to establish for.</param>
+        /// <param name="correlationId"><see cref="CorrelationId"/> to establish for.</param>
+        /// <returns>Established <see cref="ExecutionContext"/>.</returns>
+        ExecutionContext Establish(TenantId tenantId, CorrelationId correlationId);
+
+        /// <summary>
+        /// Set a <see cref="ExecutionContext"/> for current call path.
+        /// </summary>
+        /// <param name="context"><see cref="ExecutionContext"/> to set.</param>
+        void Set(ExecutionContext context);
+    }
+}

--- a/Source/DotNET/Backend/Resources/ResourcesServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/Resources/ResourcesServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.Add(new ServiceDescriptor(typeof(ResourceConfigurations), resourceConfigurations));
             services.Add(new ServiceDescriptor(typeof(IMongoDatabase), (provider) =>
             {
-                var tenant = ExecutionContextManager.Current.Tenant;
+                var tenant = ExecutionContextManager.GetCurrent().Tenant;
                 if (_mongoDatabaseByTenant.ContainsKey(tenant))
                 {
                     return _mongoDatabaseByTenant[tenant];

--- a/Source/DotNET/Backend/VanirAppBuilderExtensions.cs
+++ b/Source/DotNET/Backend/VanirAppBuilderExtensions.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Builder
 {
-
     public static class VanirAppBuilderExtensions
     {
         public static void UseVanir(this IApplicationBuilder app)
@@ -71,7 +70,6 @@ namespace Microsoft.AspNetCore.Builder
                     logger.LogInformation($"Hosting Playground at '{configuration.GraphQLPlaygroundRoute}'");
                     _.MapGraphQLPlayground(new PlaygroundOptions { GraphQLEndPoint = configuration.GraphQLRoute }, configuration.GraphQLPlaygroundRoute);
                 }
-
 
                 logger.LogInformation($"GraphQL endpoint is located at '{configuration.GraphQLRoute}'");
                 _.MapGraphQL(configuration.GraphQLRoute).WithOptions(new GraphQLServerOptions

--- a/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var configuration = services.AddVanirConfiguration();
             services.AddDolittle(configuration, arguments, types);
+            services.AddExecutionContext();
             services.AddGraphQL(container, arguments, types);
 
             services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);


### PR DESCRIPTION
### Added

- [C#] `IExecutionContextManager` interface - making it possible not lock one into the implementation. This enables more predictability for automated tests, which could potentially have side-effects with its async local implementation for holding current.

