### PR TITLE
small-bug-fixes

### DIFF
--- a/Source/DotNET/Backend/BackendArguments.cs
+++ b/Source/DotNET/Backend/BackendArguments.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Extensions.DependencyInjection
     public class BackendArguments
     {
         public ILoggerFactory LoggerFactory { get; set; } = new NullLoggerFactory();
-        public Action<IRequestExecutorBuilder> GraphQLExecutorBuilder = (b) => {};
-        public Action<ClientBuilder> DolittleClientBuilderCallback = (b) => {};
-        public Action<MongoClientSettings> MongoClientSettingsCallback = (b) => {};
+        public Action<IRequestExecutorBuilder> GraphQLExecutorBuilder = (b) => { };
+        public Action<ClientBuilder> DolittleClientBuilderCallback = (b) => { };
+        public Action<MongoClientSettings> MongoClientSettingsCallback = (b) => { };
 
         /// <summary>
         /// Setting indicating whether or not to automatically forward all public events over the Dolittle Event Horizon or not.
@@ -25,5 +25,13 @@ namespace Microsoft.Extensions.DependencyInjection
         /// callback.
         /// </remarks>
         public bool PublishAllPublicEvents { get; set; } = true;
+
+        /// <summary>
+        /// Indicating whether or not to automatically expose events in GraphQL schema when running in development.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to true.
+        /// </remarks>
+        public bool ExposeEventsInGraphQLSchema { get; set; } = true;
     }
 }

--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (RuntimeEnvironment.isDevelopment)
             {
-                mutations.AddEventsAsMutations(types);
+                if (arguments.ExposeEventsInGraphQLSchema) mutations.AddEventsAsMutations(types);
                 graphQLBuilder.AddApolloTracing();
             }
         }

--- a/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static Services AddVanir(this IServiceCollection services, BackendArguments arguments = null)
         {
+            if (arguments == null) arguments = new();
+
             var container = new Container();
             services.AddSingleton<IContainer>(container);
             var types = new Types();

--- a/Source/typescript/features/featureDecorator.ts
+++ b/Source/typescript/features/featureDecorator.ts
@@ -4,7 +4,5 @@
 export function feature(name: string): ClassDecorator & MethodDecorator;
 export function feature(name: string): ClassDecorator | MethodDecorator {
     return function (target: any, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<any>) {
-    }
+    };
 }
-
-

--- a/Source/typescript/features/for_Dummy/when_nothing.ts
+++ b/Source/typescript/features/for_Dummy/when_nothing.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+describe('when nothing', () => {
+    it('should not fail', () => true.should.be.true);
+});


### PR DESCRIPTION
### Added

- [C#] `BackendArguments` now have a property called `ExposeEventsInGraphQLSchema` that enables you to disable the exposure of events in the GraphQL schema in development mode. This setting is set to true as default.

### Fixed

- [C#] Crash when not passing in a `BackendArguments` instance to `.AddVanir()` (#223). It is now possible to not pass anything in.

