### PR TITLE
Add flexibility for Startup configuration

### DIFF
--- a/Documentation/backend/DotNET/index.md
+++ b/Documentation/backend/DotNET/index.md
@@ -4,5 +4,6 @@
 
 | Title | Description |
 | ----- | ----------- |
+| [Startup](./startup.md) | How to configure `Startup.cs` |
 | [Validation](./validation.md) | How validation works |
 | [Authorization](./authorization.md) | How to enable authorization |

--- a/Documentation/backend/DotNET/startup.md
+++ b/Documentation/backend/DotNET/startup.md
@@ -1,0 +1,121 @@
+# Configuring Startup.cs
+
+Vanir provides flexibility in how you configure your application startup and the goal is for
+it to not be obtrusive.
+
+## .AddVanir() / .UseVanir() / .MapGraphQL()
+
+If you want to control of your services and the middleware pipelines, the least opinionated setup
+would be to use the `.AddVanir()` and `.UseVanir()` methods in your `Startup` type:
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddVanir();
+        services.AddControllers();
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseDefaultFiles();
+        app.UseStaticFiles();
+
+        app.UseVanir();
+
+        app.UseRouting();
+        app.UseEndpoints(_ =>
+        {
+            _.MapControllers();
+            _.MapDefaultControllerRoute();
+            _.MapGraphQL(app);
+        });
+    }
+}
+```
+
+### .AddVanir()
+
+With `.AddVanir()` you get a setup that configures the following:
+
+- Dolittle client
+- [HotChocolate](https://chillicream.com/docs/hotchocolate/) GraphQL
+- MongoDB defaults and serializers
+- Resource management according to the [Dolittle platform requirements](https://dolittle.io/docs/platform/requirements/) supporting the [resource.json](https://dolittle.io/docs/reference/runtime/configuration/#resourcesjson) file format.
+
+#### Backend Arguments
+
+Optionally you can provide an instance of a type called `BackendArguments`.
+On this type you'll find ways to amend the Dolittle client builder, GraphQL builder and Mongo client settings.
+It also provides configuration for controlling the behavior of Vanir:
+
+| Property Name | Description | Default Value |
+| ------------- | ----------- | ------------- |
+| LoggerFactory | One can provide an instance of logger factory of the type `Microsoft.Extensions.Logging.ILoggerFactory` | NullLoggerFactory |
+| GraphQLExecutorBuilder | Callback for building on the [GraphQL builder](https://chillicream.com/docs/hotchocolate/api-reference/migrate-from-10-to-11/#configureservices) | N/A |
+| DolittleClientBuilderCallback | Calllback for building on the [Dolittle client builder](https://dolittle.io/docs/tutorials/getting_started/#connect-the-client-and-commit-an-event) | N/A |
+| MongoClientSettingsCallback | Callback for configuring the [MongoDB Driver settings](https://mongodb.github.io/mongo-csharp-driver/2.7/apidocs/html/T_MongoDB_Driver_MongoClientSettings.htm) | N/A |
+| PublishAllPublicEvents | Whether or not to add a [filter](https://dolittle.io/docs/concepts/event_handlers_and_filters/#filters) for publishing all events marked as public | True |
+| ExposeEventsInGraphQLSchema | Whether or not to add a `events` field with all events as mutations in the GraphQL Schema (development only) | True |
+
+### .MapGraphQL()
+
+The GraphQL endpoint is added when using the `.MapGraphQL()`. In addition to this, in *development* it will also add
+the GraphQL playground, available at the same URL as the GraphQL endpoint with a `/ui` appended (e.g. `/graphql/ui`).
+The `.MapGraphQL()` is an extension method for `IEndpointRouteBuilder`.
+
+## .AddVanirWithCommon() / .UseVanirWithCommon()
+
+If your needs does not require a lot of flexibility and you're good with Vanir making the choices
+for you; you can use the common setup.
+
+The simplest thing that will get you going with the common setup is as follows:
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddVanirWithCommon();
+    }
+
+    public void Configure(IApplicationBuilder app)
+    {
+        app.UseVanirWithCommon();
+    }
+}
+```
+
+The `Add/Use-VanirWithCommon()` methods both call into the `Add/Use-Vanir()` methods, but in addition
+to this sets up the following with defaults:
+
+- Swagger
+- Controllers
+- Static Files
+
+> Note: The `.AddVanirWithCommon()` also accepts taking the `BackendArguments` as described earlier.
+
+## More flexibility
+
+Looking at what the different extension methods do, you'll see that all they do is compose together
+default combinations of things through delegating to other implementations within Vanir.
+That means that if you want to, you can take full control over the startup process.
+
+The following extension methods for `IServiceCollection` are available:
+
+| Method | Description |
+| ------ | ----------- |
+| .AddVanirConfiguration() | Reads the `vanir.json` file and adds its configuration as a configuration object |
+| .AddDolittle() | Builds the Dolittle client based on the configuration |
+| .AddGraphQL() | Builds the GraphQL Hot Chocolate schema |
+| .AddMongoDB() | Adds the MongoDB default settings and serializers |
+| .AddResources() | Adds resources that are according to the current execution context, relies on the execution context being configured properly, which .AddDolittle() includes for instance. |
+| .AddExecutionContext() | Registers the `IExecutionContextManager` and prepares for execution context to work |
+
+The following extension methods for `IApplicationBuilder` are available:
+
+| Method | Description |
+| ------ | ----------- |
+| .UseDolittle() | Starts the Dolittle client |
+| .UseGraphQL() | Configures GraphQL endpoints |

--- a/Samples/Source/Aspnetcore/Backend/Startup.cs
+++ b/Samples/Source/Aspnetcore/Backend/Startup.cs
@@ -41,7 +41,7 @@ namespace Backend
                 .AddPolicy("MyPolicy", policy =>
                  policy.RequireClaim("Admin")));
 
-            services.AddVanir(new()
+            services.AddVanirWithCommon(new()
             {
                 LoggerFactory = loggerFactory,
                 GraphQLExecutorBuilder = (IRequestExecutorBuilder _) =>
@@ -63,7 +63,7 @@ namespace Backend
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseVanir();
+            app.UseVanirWithCommon();
         }
     }
 }

--- a/Source/DotNET/Backend/Dolittle/DolittleAppBuilderExtensions.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleAppBuilderExtensions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.Builder
         public static void UseDolittle(this IApplicationBuilder app)
         {
             ThrowIfClientBuilderNotCreated();
+            app.UseExecutionContext();
+            DolittleContainer.ServiceProvider = app.ApplicationServices;
             var client = DolittleServiceCollectionExtensions.DolittleClientBuilder.Build();
             client.WithContainer(new DolittleContainer()).Start();
             DolittleServiceCollectionExtensions.DolittleClient = client;

--- a/Source/DotNET/Backend/Dolittle/DolittleServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleServiceCollectionExtensions.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 return DolittleClient.EventTypes;
             });
 
+            services.AddExecutionContext();
+
             DolittleClientBuilder = clientBuilder;
         }
 

--- a/Source/DotNET/Backend/GraphQL/GraphQLAppBuilderExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLAppBuilderExtensions.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Vanir.Backend.Config;
+using GraphQL.Server.Ui.Playground;
+using HotChocolate.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    public static class GraphQLAppBuilderExtensions
+    {
+        public static void UseGraphQL(this IApplicationBuilder app)
+        {
+            var env = app.ApplicationServices.GetService<IWebHostEnvironment>();
+            var logger = app.ApplicationServices.GetService<ILogger<Dolittle.Vanir.Backend.Vanir>>();
+            var configuration = app.ApplicationServices.GetService<Configuration>();
+
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Path.Value == configuration.GraphQLRoute && !context.Request.HasJsonContentType())
+                {
+                    context.Request.Path = configuration.GraphQLPlaygroundRoute;
+                }
+                await next();
+            });
+        }
+    }
+
+    public static class GraphQLEndpointRouteBuilderExtensions
+    {
+        public static void MapGraphQL(this IEndpointRouteBuilder endpoints, IApplicationBuilder app)
+        {
+            var env = app.ApplicationServices.GetService<IWebHostEnvironment>();
+            var logger = app.ApplicationServices.GetService<ILogger<Dolittle.Vanir.Backend.Vanir>>();
+            var configuration = app.ApplicationServices.GetService<Configuration>();
+
+            if (env.IsDevelopment())
+            {
+                logger.LogInformation($"Hosting Playground at '{configuration.GraphQLPlaygroundRoute}'");
+                endpoints.MapGraphQLPlayground(new PlaygroundOptions { GraphQLEndPoint = configuration.GraphQLRoute }, configuration.GraphQLPlaygroundRoute);
+            }
+
+            logger.LogInformation($"GraphQL endpoint is located at '{configuration.GraphQLRoute}'");
+            endpoints.MapGraphQL(configuration.GraphQLRoute).WithOptions(new GraphQLServerOptions
+            {
+                Tool = { Enable = false }
+            });
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var graphQLBuilder = services
                                     .AddGraphQLServer()
+                                    .ModifyRequestOptions(opt => opt.IncludeExceptionDetails = RuntimeEnvironment.isDevelopment)
                                     .TryAddTypeInterceptor<ReadOnlyPropertyInterceptor>()
                                     .AddAuthorization()
                                     .UseFluentValidation()

--- a/Source/DotNET/Backend/Services.cs
+++ b/Source/DotNET/Backend/Services.cs
@@ -1,12 +1,15 @@
 // Copyright (c) Dolittle. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Dolittle.Vanir.Backend.Config;
 using Dolittle.Vanir.Backend.Reflection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Dolittle.Vanir.Backend
 {
     public class Services
     {
+        public Configuration Configuration { get; init; }
+        public IContainer Container { get; init; }
         public ITypes Types { get; init; }
     }
 }

--- a/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/VanirServiceCollectionExtensions.cs
@@ -9,6 +9,16 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class VanirServiceCollectionExtension
     {
+        /// <summary>
+        /// Add the basic Vanir setup
+        /// </summary>
+        /// <param name="services"><see cref="IServiceCollection"/> to extend.</param>
+        /// <param name="arguments"><see cref="BackendArguments"/> if any - defaults to default values if not provided.</param>
+        /// <returns><see cref="Services"/></returns>
+        /// <remarks>
+        /// This configures GraphQL, Dolittle, MongoDB and multi tenant resource management according
+        /// to the requirement of the Dolittle platform (https://dolittle.io/docs/platform/requirements/).
+        /// </remarks>
         public static Services AddVanir(this IServiceCollection services, BackendArguments arguments = null)
         {
             if (arguments == null) arguments = new();
@@ -20,17 +30,37 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var configuration = services.AddVanirConfiguration();
             services.AddDolittle(configuration, arguments, types);
-            services.AddExecutionContext();
             services.AddGraphQL(container, arguments, types);
 
             services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);
 
-            services.AddControllers();
-            services.AddSwaggerGen();
             services.AddMongoDB();
             services.AddResources(arguments);
 
-            return new Services { Types = types };
+            return new Services
+            {
+                Configuration = configuration,
+                Container = container,
+                Types = types
+            };
+        }
+
+        /// <summary>
+        /// Add the basic Vanir setup with additional common setup.
+        /// </summary>
+        /// <param name="services"><see cref="IServiceCollection"/> to extend.</param>
+        /// <param name="arguments"><see cref="BackendArguments"/> if any - defaults to default values if not provided.</param>
+        /// <returns><see cref="Services"/></returns>
+        /// <remarks>
+        /// This configures GraphQL, Dolittle, MongoDB and multi tenant resource management according
+        /// to the requirement of the Dolittle platform (https://dolittle.io/docs/platform/requirements/).
+        /// </remarks>
+        public static Services AddVanirWithCommon(this IServiceCollection services, BackendArguments arguments = null)
+        {
+            var result = services.AddVanir(arguments);
+            services.AddControllers();
+            services.AddSwaggerGen();
+            return result;
         }
     }
 }


### PR DESCRIPTION
### Added

- Documentation added for how `Startup` works
- Includes exception details during development on GraphQL operations

### Changed

- `.AddVanir()` and `.UseVanir()` are less opionated. If one wants the same level of opinions, use `.AddVanirWithCommon()` and `.UseVanirWithCommon()`.
