### PR TITLE
enum-as-int

### DIFF
--- a/Samples/Source/Aspnetcore/Backend/Owner.cs
+++ b/Samples/Source/Aspnetcore/Backend/Owner.cs
@@ -11,6 +11,12 @@ namespace Backend
         public static implicit operator OwnerId(Guid id) => new() { Value = id };
     }
 
+    public enum OwnerType
+    {
+        Awesome=1,
+        Possum
+    }
+
     public class Owner
     {
         [Key]
@@ -22,5 +28,6 @@ namespace Backend
         public CommonObject CommonObject { get; set; }
 
         public int ReadOnlyProperty => 42;
+        public OwnerType Type { get; set; } = OwnerType.Awesome;
     }
 }

--- a/Source/DotNET/Backend/GraphQL/EnumToIntConverter.cs
+++ b/Source/DotNET/Backend/GraphQL/EnumToIntConverter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using HotChocolate.Utilities;
+
+namespace Dolittle.Vanir.Backend.GraphQL
+{
+    public class EnumToIntConverter : IChangeTypeProvider
+    {
+        readonly Type _enumType;
+
+        public EnumToIntConverter(Type enumType)
+        {
+            _enumType = enumType;
+        }
+
+        public bool TryCreateConverter(Type source, Type target, ChangeTypeProvider root, [NotNullWhen(true)] out ChangeType converter)
+        {
+            converter = (source) => (int)source;
+            return source == _enumType;
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLServiceCollectionExtensions.cs
@@ -63,6 +63,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddMutations(graphControllers, namingConventions, out SchemaRoute mutations);
 
             types.FindMultiple(typeof(ConceptAs<>)).ForEach(_ => graphQLBuilder.AddConceptTypeConverter(_));
+            types.All.Where(_ => _.IsEnum).ForEach(type =>
+            {
+                graphQLBuilder.BindRuntimeType(type, typeof(IntType));
+                graphQLBuilder.AddTypeConverter(_ => new EnumToIntConverter(type));
+            });
 
             services.AddSingleton<INamingConventions>(namingConventions);
 


### PR DESCRIPTION
### Fixed

- [C#] For consistency with the Node version, we want enums to be integers by default - by default now it adds a type conversion for this.
