### PR TITLE
Recursively getting the types from the actual aggregated queries and mutations for enums

### DIFF
--- a/Source/DotNET/Backend/GraphQL/EnumExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/EnumExtensions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dolittle.Vanir.Backend.Collections;
+using HotChocolate.Execution.Configuration;
+using HotChocolate.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dolittle.Vanir.Backend.GraphQL
+{
+    public static class EnumExtensions
+    {
+        public static void RegisterAllEnumsFor(this IRequestExecutorBuilder builder, SchemaRoute route, Dictionary<Type, Type> scannedTypes = null)
+        {
+            if (scannedTypes == null) scannedTypes = new();
+
+            var types = new List<Type>();
+            foreach (var item in route.Items)
+            {
+                var parameterTypes = item.Method.GetParameters()
+                                            .Where(_ => !_.ParameterType.IsPrimitive)
+                                            .Select(_ => _.ParameterType);
+                types.AddRange(parameterTypes.Where(_ => !types.Contains(_)));
+
+                var returnType = item.Method.ReturnType;
+                while (returnType.IsGenericType)
+                {
+                    returnType = returnType.GetGenericArguments()[0];
+                }
+
+                if (!types.Contains(returnType)) types.Add(returnType);
+            }
+
+            var typesToScan = types.Where(_ => !scannedTypes.Keys.Contains(_) && !_.Namespace.StartsWith("System"));
+
+            void TypeScanner(Type type)
+            {
+                var enumTypes = type.GetProperties()
+                                    .Where(_ => _.PropertyType.IsEnum)
+                                    .Select(_ => _.PropertyType);
+
+                enumTypes.ForEach(_ => builder.RegisterEnumType(_));
+
+                var complexProperties = type.GetProperties()
+                                            .Where(_ => !_.PropertyType.IsPrimitive)
+                                            .Select(_ => _.PropertyType);
+                complexProperties.ForEach(TypeScanner);
+
+                scannedTypes[type] = type;
+            }
+
+            typesToScan.ForEach(TypeScanner);
+
+            foreach (var child in route.Children)
+            {
+                RegisterAllEnumsFor(builder, child, scannedTypes);
+            }
+        }
+
+        public static void RegisterEnumType(this IRequestExecutorBuilder builder, Type type)
+        {
+            builder.BindRuntimeType(type, typeof(IntType));
+            builder.AddTypeConverter(_ => new EnumToIntConverter(type));
+        }
+    }
+}

--- a/Source/DotNET/Backend/GraphQL/EnumExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/EnumExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Dolittle.Vanir.Backend.Collections;
 using HotChocolate.Execution.Configuration;
 using HotChocolate.Types;

--- a/Source/DotNET/Backend/GraphQL/GraphQLBuilderExtensions.cs
+++ b/Source/DotNET/Backend/GraphQL/GraphQLBuilderExtensions.cs
@@ -22,9 +22,9 @@ namespace Dolittle.Vanir.Backend.GraphQL
             public MethodInfo Method { get; set; }
         }
 
-        public static IRequestExecutorBuilder AddQueries(this IRequestExecutorBuilder builder, IGraphControllers graphControllers, INamingConventions namingConventions)
+        public static IRequestExecutorBuilder AddQueries(this IRequestExecutorBuilder builder, IGraphControllers graphControllers, INamingConventions namingConventions, out SchemaRoute query)
         {
-            var query = BuildSchemaRoutesWithItems<QueryAttribute>("Query", graphControllers, namingConventions, "Queries");
+            query = BuildSchemaRoutesWithItems<QueryAttribute>("Query", graphControllers, namingConventions, "Queries");
             builder.AddQueryType(query);
             return builder;
         }

--- a/Source/DotNET/Backend/GraphQL/SchemaRoute.cs
+++ b/Source/DotNET/Backend/GraphQL/SchemaRoute.cs
@@ -23,6 +23,9 @@ namespace Dolittle.Vanir.Backend.GraphQL
         public string LocalName { get; }
         public string TypeName { get; }
 
+        public IEnumerable<SchemaRoute> Children => _children;
+        public IEnumerable<SchemaRouteItem> Items => _items;
+
         public void AddChild(SchemaRoute child)
         {
             _children.Add(child);


### PR DESCRIPTION
### Fixed

- [C#] Support type conversion to integer for enum types on the actual ObjectTypes and InputObjectTypes used by queries and mutations. This enables enums from 3rd party assemblies.
