### PR TITLE
Reorder initialization to make Client object available for IOC

### DIFF
--- a/Source/DotNET/Backend/Dolittle/DolittleAppBuilderExtensions.cs
+++ b/Source/DotNET/Backend/Dolittle/DolittleAppBuilderExtensions.cs
@@ -15,8 +15,8 @@ namespace Microsoft.AspNetCore.Builder
             app.UseExecutionContext();
             DolittleContainer.ServiceProvider = app.ApplicationServices;
             var client = DolittleServiceCollectionExtensions.DolittleClientBuilder.Build();
-            client.WithContainer(new DolittleContainer()).Start();
             DolittleServiceCollectionExtensions.DolittleClient = client;
+            client.WithContainer(new DolittleContainer()).Start();
         }
 
         static void ThrowIfClientBuilderNotCreated()


### PR DESCRIPTION
### Fixed

- [C#] Fixing so that the Client instance is set before we start the client - this will then make IoC resolver callbacks relying directly or indirectly work.

