### PR TITLE
Moving express callback earlier

### DIFF
--- a/Source/typescript/backend/web/Express.ts
+++ b/Source/typescript/backend/web/Express.ts
@@ -54,6 +54,7 @@ export async function initialize(configuration: Configuration, backendArguments:
     });
 
     logger.info(`Hosting graphql at ${graphqlRoute}`);
+    backendArguments.expressCallback?.(app);
 
     apolloServer.applyMiddleware({ app, path: graphqlRoute });
 
@@ -71,7 +72,6 @@ export async function initialize(configuration: Configuration, backendArguments:
         );
     }
 
-    backendArguments.expressCallback?.(app);
 
     logger.info(`Serving static content from '${configuration.publicPath}'`);
 


### PR DESCRIPTION
### Fixed

- [TS/JS] Express callback was too late. Moved it up the stack - before the Apollo GraphQL middlewares are applied. This enables adding middlewares much earlier.
