### PR TITLE
Making WebSocketLink use WSS if origin is TLS

### DIFF
--- a/Source/web/Bindings.ts
+++ b/Source/web/Bindings.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
-import { WebSocketLink } from '@apollo/client/link/ws';
+import { WebSocketLink } from '@apollo/client/link/ws';
 import { container } from 'tsyringe';
 import { constructor } from '@dolittle/vanir-dependency-inversion';
 import { DataSource } from './DataSource';
@@ -39,8 +39,9 @@ export class Bindings {
         });
         container.registerInstance(DataSource as constructor<DataSource>, dataClient);
 
+        const wsProtocol = document.location.protocol.indexOf('https') == 0 ? 'wss' : 'ws';
         const subscriptionLink = new WebSocketLink({
-            uri: `ws://${window.location.host}${configuration.prefix}/graphql`,
+            uri: `${wsProtocol}://${window.location.host}${configuration.prefix}/graphql`,
             options: {
                 reconnect: true
             }


### PR DESCRIPTION
### Fixed

- [Web] Fixing so that when origin of document is HTTPS we use WSS for WebSocketLink for GraphQL and WS if HTTP.
