### PR TITLE
Upgrading SDK + Projections

### DIFF
--- a/Source/typescript/backend/package.json
+++ b/Source/typescript/backend/package.json
@@ -36,8 +36,8 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
-        "@dolittle/projections": "2.1.1",
-        "@dolittle/sdk": "14.4.0",
+        "@dolittle/projections": "2.1.2",
+        "@dolittle/sdk": "16.0.0",
         "@dolittle/vanir-dependency-inversion": "9.30.7",
         "@dolittle/vanir-features": "9.30.7",
         "@types/mongodb": "3.6.8",


### PR DESCRIPTION
### Fixed

- [Node] Upgrading to version 16.0.0 of the Dolittle SDK and 2.1.2 of the Dolittle Projections.

