### PR TITLE
Update .NET SDK version

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <DolittleSdkVersion>8.4.0</DolittleSdkVersion>
+        <DolittleSdkVersion>9.0.0</DolittleSdkVersion>
         <MicrosoftDotNetTestVersion>16.4.0</MicrosoftDotNetTestVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>


### PR DESCRIPTION
### Fixed

- [.NET] Upgrade to version 9.0.0 of the Dolittle SDK