### PR TITLE
Upgrading to version 2.1.3 of Projections + 17.0.1 of SDK

### DIFF
--- a/Source/typescript/backend/package.json
+++ b/Source/typescript/backend/package.json
@@ -36,8 +36,8 @@
         "ci": "yarn clean && yarn lint:ci && yarn build && yarn test"
     },
     "dependencies": {
-        "@dolittle/projections": "2.1.2",
-        "@dolittle/sdk": "16.0.0",
+        "@dolittle/projections": "2.1.3",
+        "@dolittle/sdk": "17.0.1",
         "@dolittle/vanir-dependency-inversion": "9.30.9",
         "@dolittle/vanir-features": "9.30.9",
         "@types/mongodb": "3.6.8",

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <DolittleSdkVersion>9.0.0</DolittleSdkVersion>
+        <DolittleSdkVersion>9.1.0</DolittleSdkVersion>
         <MicrosoftDotNetTestVersion>16.4.0</MicrosoftDotNetTestVersion>
         <MachineSpecificationsRunnerVersion>2.9.0</MachineSpecificationsRunnerVersion>
         <MachineSpecificationsVersion>1.0.0</MachineSpecificationsVersion>


### PR DESCRIPTION
### Fixed

- Upgraded to version 17.0.1 of the Dolittle SDK
- Upgraded to version 2.1.3 of Dolittle Entropy Projections (for compatibility with SDK)
