### PR TITLE
Update @webpack-cli dependency for webpack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-node:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:  ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
 
 
   build-dotnet:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on:  ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/Source/webpack/package.json
+++ b/Source/webpack/package.json
@@ -43,7 +43,7 @@
         "tsconfig-paths-webpack-plugin": "3.3.0",
         "url-loader": "4.1.1",
         "webpack": "5.22.0",
-        "webpack-cli": "4.5.0",
+        "webpack-cli": "4.9.1",
         "webpack-dev-server": "3.11.2"
     }
 }


### PR DESCRIPTION
## Summary

Freshly cloned projects using Vanir Frontend were getting the following issue: 

```
"[webpack-cli] Unable to load '@webpack-cli/serve' command
[webpack-cli] TypeError: options.forEach is not a function"
```
An updated webpack-cli fixes the issue.

This was tested by @vstdolittle and @soumikgm 

