### PR TITLE
feat(validation): use the existing errors array as context.Result, in…

### DIFF
--- a/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
+++ b/Source/DotNET/Backend/GraphQL/Validation/ValidationMiddleware.cs
@@ -45,7 +45,7 @@ namespace Dolittle.Vanir.Backend.GraphQL.Validation
                         await CheckAndValidate(context, instance, argument.RuntimeType, errors, argument.Name).ConfigureAwait(false);
                         if (errors.Count > 0)
                         {
-                            context.Result = "errors";
+                            context.Result = errors;
                             return;
                         }
                     }


### PR DESCRIPTION
## Summary

We found that many of our application errors masked as `EXEC_INVALID_LEAF_VALUE` with the message `Boolean cannot serialize the given value.`. 

I eventually found that for all affected mutations we always hit the validator, but never the resolver. This lead me to look closer at the validation middleware, which I found was swallowing the original errors and replacing them with the magic string `"errors"`. 

I eventually found that the root cause of this was one of our AbstractValidator's, where a RuleFor failed. However, the validation middleware currently only replaces the original error with the magic string `"errors"`


### Fixed

In `90.3.4` and earlier you'd find the following line in `Dolittle.Vanir.Backend.GraphQL.Validation.ValidationMiddleware.cs` 

```csharp
var errors = new List<IError>();
...
context.result = errors;
...
```

However, in `90.3.5` this suddenly changed to;

```csharp
var errors = new List<IError>();
....
context.result = "errors";
....
```

Notice the new value of `context.Result`.

This is obviously not intended, as you can't magically set a string on a GraphQL result, and expect it to serialize correctly.