### PR TITLE
Fix validation middleware bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,24 @@ jobs:
           version: ${{ steps.context.outputs.current-version }}
           release-type: ${{ steps.context.outputs.release-type }}
 
+      - name: Remove any existing artifacts
+        run: rm -rf ${{ env.NUGET_OUTPUT }}
+
+      - name: Create NuGet packages
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
+        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Push NuGet packages
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
+        run: dotnet nuget push --skip-duplicate '${{ env.NUGET_OUTPUT }}/*.nupkg' --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+      - name: Publish NPM packages
+        if: ${{ steps.context.outputs.should-publish == 'true' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          yarn publish-version ${{ steps.increment-version.outputs.next-version }}
+
       - name: Prepend to Changelog
         if: ${{ steps.context.outputs.should-publish == 'true' }}
         uses: dolittle/add-to-changelog-action@v2
@@ -72,24 +90,6 @@ jobs:
           token: ${{  secrets.BUILD_PAT  }}
           version: ${{ steps.increment-version.outputs.next-version }}
           body: ${{ steps.context.outputs.pr-body }}
-
-      - name: Remove any existing artifacts
-        run: rm -rf ${{ env.NUGET_OUTPUT }}
-
-      - name: Create NuGet packages
-        if: ${{ steps.context.outputs.should-publish == 'true' }}
-        run: dotnet pack --no-build --configuration Release -o ${{ env.NUGET_OUTPUT }} -p:PackageVersion=${{ steps.increment-version.outputs.next-version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-
-      - name: Push NuGet packages
-        if: ${{ steps.context.outputs.should-publish == 'true' }}
-        run: dotnet nuget push --skip-duplicate '${{ env.NUGET_OUTPUT }}/*.nupkg' --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-
-      - name: Publish NPM packages
-        if: ${{ steps.context.outputs.should-publish == 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          yarn publish-version ${{ steps.increment-version.outputs.next-version }}
 
       - name: Commit any updated packages
         if: always()


### PR DESCRIPTION
## Summary

Closes #267. Thanks @rune-wikstad! I couldn't figure out how to build a remote PR. 

Also moved the creation of a GitHub release and updating the CHANGELOG.md file to after the packages have been published in the `.github/publish.yml` action.

### Fixed

- [C#] A bug in the `ValidationMiddleware` setting `errors` to the literal string `"errors"` instead of the list of errors.